### PR TITLE
Add the maven plugin and executions to start/stop WildFly

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -117,6 +117,31 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-maven-plugin</artifactId>
+        <version>${version.org.wildfly.plugins.maven}</version>
+        <executions>
+          <execution>
+            <id>start</id>
+            <goals>
+              <goal>start</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <version>${version.wildfly}</version>
+              <server-config>standalone-full-ha.xml</server-config>
+            </configuration>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <goals>
+              <goal>shutdown</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -67,6 +67,31 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-maven-plugin</artifactId>
+        <version>${version.org.wildfly.plugins.maven}</version>
+        <executions>
+          <execution>
+            <id>start</id>
+            <goals>
+              <goal>start</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <version>${version.wildfly}</version>
+              <server-config>standalone-full-ha.xml</server-config>
+            </configuration>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <goals>
+              <goal>shutdown</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 
   <properties>
     <version.wildfly>10.0.0.CR3</version.wildfly>
+    <version.org.wildfly.plugins.maven>1.0.2.Final</version.org.wildfly.plugins.maven>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
This was just an idea I had while looking at the project. This downloads, if required, starts and then stops WildFly during the build process so you don't have to manually start it. No biggie if we don't want something like thisl
