### PR TITLE
Add additional subsystems to the config API

### DIFF
--- a/api/src/main/resources/generator-config.json
+++ b/api/src/main/resources/generator-config.json
@@ -11,6 +11,10 @@
       "targetPackage": "org.wildfly.swarm.config.management"
     },
     {
+      "sourceAddress": "/subsystem=batch-jberet",
+      "targetPackage": "org.wildfly.swarm.config.batch.jberet"
+    },
+    {
       "sourceAddress": "/subsystem=bean-validation",
       "targetPackage": "org.wildfly.swarm.config.bean.validation"
     },
@@ -75,8 +79,16 @@
       "targetPackage": "org.wildfly.swarm.config.remoting"
     },
     {
+      "sourceAddress": "/subsystem=sar",
+      "targetPackage": "org.wildfly.swarm.config.sar"
+    },
+    {
       "sourceAddress": "/subsystem=security",
       "targetPackage": "org.wildfly.swarm.config.security"
+    },
+    {
+      "sourceAddress": "/subsystem=security-manager",
+      "targetPackage": "org.wildfly.swarm.config.security.manager"
     },
     {
       "sourceAddress": "/subsystem=transactions",

--- a/generator/src/main/java/org/wildfly/swarm/config/generator/generator/Generator.java
+++ b/generator/src/main/java/org/wildfly/swarm/config/generator/generator/Generator.java
@@ -53,7 +53,7 @@ public class Generator {
         try {
             client = ClientFactory.createClient(config);
         } catch (Exception e) {
-            log.log(Level.ERROR, "Failed to create model controller client", e);
+            throw new RuntimeException("Failed to create model controller client", e);
         }
 
     }
@@ -62,14 +62,12 @@ public class Generator {
         log.info("Config: " + args[0]);
         log.info("Output: " + args[1]);
 
+        Config config = Config.fromJson(args[0]);
+        Generator generator = new Generator(args[1], config);
         try {
-            Config config = Config.fromJson(args[0]);
-            Generator generator = new Generator(args[1], config);
             generator.processGeneratorTargets();
+        } finally {
             generator.shutdown();
-        } catch (Throwable e) {
-            System.exit(-1);
-            log.log(Level.ERROR, "Unexpected error", e);
         }
     }
 


### PR DESCRIPTION
The first commit just allows maven to fail if a parsing or processing error is thrown. I had an extra comma in the JSON I missed and the build ended, not failed, with the `System.exit(-1)`.

The second commit just adds more subsystems to the config. 

Note that the `iiop-openjdk` and `resource-adaptors` subsystems could not be added because of name clashes. It seems the `targetPackage` in the `generator-config.json` is ignored. Some thought would need to go into fixing though as it would break any current API usage if the package name change.
