### PR TITLE
Fix subresource-ordering for logging subsystem

### DIFF
--- a/runtime/src/main/java/org/wildfly/swarm/config/runtime/invocation/SubresourceFilter.java
+++ b/runtime/src/main/java/org/wildfly/swarm/config/runtime/invocation/SubresourceFilter.java
@@ -53,16 +53,17 @@ class SubresourceFilter {
         return methods;
     }
 
-    private class LoggingComparator implements Comparator<Method> {
+    static class LoggingComparator implements Comparator<Method> {
         @Override
         public int compare(Method o1, Method o2) {
             if (o1.getName().contains("Formatter") ) return -1;
+            if (o2.getName().contains("Formatter") ) return 1;
             if ( o1.getName().equals( "loggers" ) || o1.getName().equals( "rootLogger" )) return 1;
             return -1;
         }
     }
 
-    private class DefaultComparator implements Comparator<Method> {
+    private static class DefaultComparator implements Comparator<Method> {
 
         @Override
         public int compare(Method o1, Method o2) {

--- a/runtime/src/test/java/org/wildfly/swarm/config/logging/TestLogging.java
+++ b/runtime/src/test/java/org/wildfly/swarm/config/logging/TestLogging.java
@@ -1,0 +1,48 @@
+package org.wildfly.swarm.config.logging;
+
+import org.wildfly.swarm.config.runtime.Subresource;
+
+public class TestLogging {
+
+    @Subresource
+    public void periodicRotatingFileHandlers() { }
+
+    @Subresource
+    public void loggers() { }
+
+    @Subresource
+    public void asyncHandlers() { }
+
+    @Subresource
+    public void fileHandlers() { }
+
+    @Subresource
+    public void sizeRotatingFileHandlers() { }
+
+    @Subresource
+    public void syslogHandlers() { }
+
+    @Subresource
+    public void loggingProfiles() { }
+
+    @Subresource
+    public void customFormatters() { }
+
+    @Subresource
+    public void periodicSizeRotatingFileHandlers() { }
+
+    @Subresource
+    public void consoleHandlers() { }
+
+    @Subresource
+    public void logFiles() { }
+
+    @Subresource
+    public void patternFormatters() { }
+
+    @Subresource
+    public void customHandlers() { }
+
+    @Subresource
+    public void rootLogger() { }
+}

--- a/runtime/src/test/java/org/wildfly/swarm/config/runtime/invocation/LoggingComparatorTest.java
+++ b/runtime/src/test/java/org/wildfly/swarm/config/runtime/invocation/LoggingComparatorTest.java
@@ -1,0 +1,39 @@
+package org.wildfly.swarm.config.runtime.invocation;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Marco Hofstetter
+ */
+public class LoggingComparatorTest {
+
+    @Test
+    public void testFormattersFirst() throws Exception {
+        SubresourceFilter.LoggingComparator loggingComparator = new SubresourceFilter.LoggingComparator();
+
+        Assert.assertEquals(-1, loggingComparator.compare(TestClass.class.getMethod("customFormatters"), TestClass.class.getMethod("customHandlers")));
+        Assert.assertEquals(1, loggingComparator.compare(TestClass.class.getMethod("customHandlers"), TestClass.class.getMethod("customFormatters")));
+    }
+
+    @Test
+    public void testLoggersLast() throws Exception {
+        SubresourceFilter.LoggingComparator loggingComparator = new SubresourceFilter.LoggingComparator();
+
+        Assert.assertEquals(1, loggingComparator.compare(TestClass.class.getMethod("loggers"), TestClass.class.getMethod("customHandlers")));
+        Assert.assertEquals(1, loggingComparator.compare(TestClass.class.getMethod("rootLogger"), TestClass.class.getMethod("customHandlers")));
+        Assert.assertEquals(-1, loggingComparator.compare(TestClass.class.getMethod("customHandlers"), TestClass.class.getMethod("loggers")));
+        Assert.assertEquals(-1, loggingComparator.compare(TestClass.class.getMethod("customHandlers"), TestClass.class.getMethod("rootLogger")));
+    }
+
+    private static class TestClass {
+
+        public void customHandlers() { }
+
+        public void customFormatters() { }
+
+        public void loggers() { }
+
+        public void rootLogger() { }
+    }
+}

--- a/runtime/src/test/java/org/wildfly/swarm/config/runtime/invocation/SubresourceFilterTest.java
+++ b/runtime/src/test/java/org/wildfly/swarm/config/runtime/invocation/SubresourceFilterTest.java
@@ -1,0 +1,30 @@
+package org.wildfly.swarm.config.runtime.invocation;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.swarm.config.logging.TestLogging;
+
+/**
+ * @author Marco Hofstetter
+ */
+public class SubresourceFilterTest {
+
+    @Test
+    public void testLoggingSubresourceOrdering() throws Exception {
+
+        SubresourceFilter subresourceFilter = new SubresourceFilter(TestLogging.class);
+
+        List<Method> orderedMethods = subresourceFilter.invoke();
+
+        Assert.assertEquals(TestLogging.class.getDeclaredMethods().length, orderedMethods.size());
+
+        Assert.assertTrue(orderedMethods.get(0).getName().contains("Formatter"));
+        Assert.assertTrue(orderedMethods.get(1).getName().contains("Formatter"));
+        Assert.assertTrue(orderedMethods.get(TestLogging.class.getDeclaredMethods().length -2).getName().toLowerCase().contains("logger"));
+        Assert.assertTrue(orderedMethods.get(TestLogging.class.getDeclaredMethods().length -1).getName().toLowerCase().contains("logger"));
+    }
+
+}


### PR DESCRIPTION
Formatters have to be at the beginning after ordering, but the current implementation of the LoggingComparator doesn't compare correctly. I think this ordering-issue is the reason, why i'm getting the following error when working with the logstash-fraction.

`WFLYCTL0013: Operation ("add") failed - address: ([
    ("subsystem" => "logging"),
    ("custom-handler" => "logstash-handler")
]): java.lang.IllegalArgumentException: Formatter "logstash" is not found`
