### PR TITLE
Fix enumeration generation for enums starting with a number.

### DIFF
--- a/generator/src/main/java/org/wildfly/swarm/config/generator/generator/EnumFactory.java
+++ b/generator/src/main/java/org/wildfly/swarm/config/generator/generator/EnumFactory.java
@@ -4,12 +4,9 @@ import java.util.List;
 
 import org.jboss.dmr.ModelNode;
 import org.jboss.forge.roaster.Roaster;
-import org.jboss.forge.roaster.model.JavaType;
 import org.jboss.forge.roaster.model.source.EnumConstantSource;
 import org.jboss.forge.roaster.model.source.JavaEnumSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOWED;
 
 /**
  * @author Bob McWhirter
@@ -53,6 +50,9 @@ public class EnumFactory {
             final String v = value.asString();
             // Replace - and . with _ and uppercase each character
             final StringBuilder sb = new StringBuilder();
+
+            boolean first = true;
+
             for (char c : v.toCharArray()) {
                 switch (c) {
                     case '-':
@@ -60,15 +60,46 @@ public class EnumFactory {
                         sb.append('_');
                         break;
                     }
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9': {
+                        if ( first ) {
+                            sb.append( "_" );
+                        }
+                        sb.append( c );
+                        break;
+
+                    }
                     default:
                         sb.append(Character.toUpperCase(c));
                 }
+                first = false;
             }
-            final EnumConstantSource constantSource = enumType.addEnumConstant(sb.toString());
+            final EnumConstantSource constantSource = enumType.addEnumConstant(fixSingleDigitsInEnumName(sb.toString()));
             constantSource.setConstructorArguments("\"" + value.asString() + "\"");
         });
 
         return enumType;
+    }
+
+    static String fixSingleDigitsInEnumName(String input) {
+        return input.replaceAll("^_1_", "ONE_" )
+                .replaceAll( "^_2_", "TWO_")
+                .replaceAll( "^_3_", "THREE_" )
+                .replaceAll( "^_4_", "FOUR_" )
+                .replaceAll( "^_5_", "FIVE_" )
+                .replaceAll( "^_6_", "SIX_" )
+                .replaceAll( "^_7_", "SEVEN_" )
+                .replaceAll( "^_8_", "EIGHT_" )
+                .replaceAll( "^_9_", "NINE_" )
+                .replaceAll( "^_10_", "TEN_" );
     }
 
 }


### PR DESCRIPTION
- Motivation:

For DMR configuration values that become Java enums, those that
start with a number are no legal enum values.  For instance, this
is invalid:

enum Foo {
  1_FOO,
  2_FOO
}

This would occur when a DMR value was "1-foo" or "2-foo".
- Modifications:

We now provide exceptions for enum values that start with digits.
By default, if the leading character of an enum value is a digit,
we prepend a literal underscore, resulting in

enum Foo {
  _1_FOO,
  _2_FOO
  _99_FOO
}

Additionally, we perform another pass for those enums that have a
single digit at the head, and replace it with the english equivalent,
which would result in

enum Foo {
  ONE_FOO,
  TWO_FOO,
  _99_FOO
}

The idea being that for single digits, we can avoid the ugliness of
the prepended underscore, as the only case we've seen thus far is
2_WAY and 3_WAY which become TWO_WAY and THREE_WAY.
- Result:

Teiid's config-api now generates compilable code.
