### PR TITLE
SWARM-617: Update to WildFly 10.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   </scm>
 
   <properties>
-    <version.wildfly>10.0.0.Final</version.wildfly>
+    <version.wildfly>10.1.0.Final</version.wildfly>
     <version.org.wildfly.plugins.maven>1.0.2.Final</version.org.wildfly.plugins.maven>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
## Motivation

Newer WildFly is out.  We should use it.
## Modifications

Adjusted versions of WildFly in pom.xml.
## Result

We are now based upon a newer version of WildFly.
