### PR TITLE
SWARM-909 @Configurable doesn't work from wildfly-swarm:run/IDE

### DIFF
--- a/generator/src/main/java/org/wildfly/swarm/config/generator/generator/Generator.java
+++ b/generator/src/main/java/org/wildfly/swarm/config/generator/generator/Generator.java
@@ -178,6 +178,8 @@ public class Generator {
                             out.println("        <path name=\"" + e.replace('.', '/') + "\"/>");
                         });
 
+                out.println("        <path name=\"org/wildfly/swarm/config/runtime\"/>");
+
                 out.println("      </paths>\n" +
                         "    </system>\n" +
                         "    <module name=\"org.wildfly.swarm.configuration\" slot=\"api\" export=\"true\" services=\"export\"/>\n" +


### PR DESCRIPTION
Motivation
----------

All execution modes should function appropriately.  Due to
classloader issues, the application of project-stages.yml
to @Configurable when running in any mode other than uberjar
failed to function correctly.

Modifications
-------------

Adjust the generated module.xml to ensure that the @SubresourceInfo
annotation can be found from the system-classpath in the mvn/ide
execution modes, to ensure out check for the presence of the
annotation succeeds, instead of failing because the annotation
is there, but compared against the same annotation from a different
class.

Result
------

wildfly-swarm:run/IDE execution modes now respect project-stages.yml
and @Configurable.