### PR TITLE
SWARM-992: Set a modifiable List to a field in var-args mutator method of List type model to enable the field to mutate

### DIFF
--- a/generator/src/main/java/org/wildfly/swarm/config/generator/generator/ResourceFactory.java
+++ b/generator/src/main/java/org/wildfly/swarm/config/generator/generator/ResourceFactory.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import com.google.common.base.CaseFormat;
 import org.jboss.dmr.ModelType;
@@ -279,6 +280,7 @@ public class ResourceFactory implements SourceFactory {
                                 // initialize the field to an array list
                                 //attributeField.setLiteralInitializer("new java.util.ArrayList<>()");
                                 type.addImport(Arrays.class);
+                                type.addImport(Collectors.class);
                                 final MethodSource<JavaClassSource> appender = type.addMethod();
                                 appender.getJavaDoc().setText(attributeDescription);
                                 appender.addParameter(Types.resolveValueType(att.getValue()), "value");
@@ -296,7 +298,7 @@ public class ResourceFactory implements SourceFactory {
                                 varargs.setPublic()
                                         .setName(name)
                                         .setReturnType("T")
-                                        .setBody(name + "(Arrays.asList( args )); return (T) this;")
+                                        .setBody(name + "(Arrays.stream(args).collect(Collectors.toList())); return (T) this;")
                                         .addAnnotation("SuppressWarnings").setStringValue("unchecked");
 
                             } else if (modelType == ModelType.OBJECT) {


### PR DESCRIPTION
Motivation
----------
The var-args mutator for some models whose type is List sets
an unmodifiable List(jva.util.Arrays$ArrayList) to the field.

If the field initializes as
java.util.Arrays$ArrayList, we can't add elements to the field.

Modifications
-------------
Use java.util.stream.Collectors#toList() to get a modifiable List(java.util.ArrayList).

Result
------
You can add elements to the initialized field.