### PR TITLE
[SWARM-1987] properly support composite types in Config API

### DIFF
--- a/runtime/src/main/java/org/wildfly/swarm/config/runtime/invocation/EntityAdapter.java
+++ b/runtime/src/main/java/org/wildfly/swarm/config/runtime/invocation/EntityAdapter.java
@@ -235,14 +235,13 @@ public class EntityAdapter<T> {
                         ModelType dmrType = Types.resolveModelType(propertyType);
 
                         if (dmrType == ModelType.LIST) {
-                            new ListTypeAdapter().toDmr(modelNode, detypedName, (List) value);
+                            new ListTypeAdapter().toDmr(modelNode.get(detypedName), (List) value);
 
                         } else if (dmrType == ModelType.OBJECT) {
-                            // only Map<String,String> supported
-                            new MapTypeAdapter().toDmr(modelNode, detypedName, (Map) value);
+                            new MapTypeAdapter().toDmr(modelNode.get(detypedName), (Map) value);
 
                         } else {
-                            new SimpleTypeAdapter().toDmr(modelNode, detypedName, dmrType, value);
+                            new SimpleTypeAdapter().toDmr(modelNode.get(detypedName), dmrType, value);
                         }
                     } catch (RuntimeException e) {
                         throw new RuntimeException("Failed to adopt value " + propertyType.getName(), e);
@@ -334,14 +333,14 @@ public class EntityAdapter<T> {
                             ModelType dmrType = Types.resolveModelType(propertyType);
 
                             if (dmrType == ModelType.LIST) {
-                                new ListTypeAdapter().toDmr(modelNode, detypedName, (List) propertyValue);
+                                new ListTypeAdapter().toDmr(modelNode.get(detypedName), (List) propertyValue);
 
                             } else if (dmrType == ModelType.OBJECT) {
                                 // only Map<String,String> supported
-                                new MapTypeAdapter().toDmr(modelNode, detypedName, (Map) propertyValue);
+                                new MapTypeAdapter().toDmr(modelNode.get(detypedName), (Map) propertyValue);
 
                             } else {
-                                new SimpleTypeAdapter().toDmr(modelNode, detypedName, dmrType, propertyValue);
+                                new SimpleTypeAdapter().toDmr(modelNode.get(detypedName), dmrType, propertyValue);
                             }
                         } catch (RuntimeException e) {
                             throw new RuntimeException("Failed to adopt value " + propertyType.getName(), e);

--- a/runtime/src/main/java/org/wildfly/swarm/config/runtime/invocation/MapTypeAdapter.java
+++ b/runtime/src/main/java/org/wildfly/swarm/config/runtime/invocation/MapTypeAdapter.java
@@ -17,12 +17,23 @@ import static java.util.Collections.*;
  */
 public class MapTypeAdapter {
 
-    public void toDmr(ModelNode modelMode, String detypedName, Map<String,String> map) {
-        for (Map.Entry<String, String> entry : map.entrySet()) {
-            modelMode.get(detypedName).get(entry.getKey()).set(entry.getValue());
+    public void toDmr(ModelNode target, Map<String, Object> map) {
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            ModelNode node = target.get(entry.getKey());
+            Object value = entry.getValue();
+
+            if (value instanceof List) {
+                new ListTypeAdapter().toDmr(node, (List) value);
+            } else if (value instanceof Map) {
+                new MapTypeAdapter().toDmr(node, (Map) value);
+            } else {
+                ModelType type = Types.resolveModelType(value.getClass());
+                new SimpleTypeAdapter().toDmr(node, type, value);
+            }
         }
     }
 
+    // TODO handle composite values
     public void fromDmr(Object entity, String javaName, ModelType dmrType, Class<?> propertyType, ModelNode dmrPayload) throws Exception {
 
         Method target = entity.getClass().getMethod(javaName, propertyType);

--- a/runtime/src/main/java/org/wildfly/swarm/config/runtime/invocation/SimpleTypeAdapter.java
+++ b/runtime/src/main/java/org/wildfly/swarm/config/runtime/invocation/SimpleTypeAdapter.java
@@ -14,12 +14,7 @@ import org.jboss.dmr.ValueExpression;
  */
 public class SimpleTypeAdapter {
 
-    public void toDmr(ModelNode target, String detypedName, ModelType dmrType, Object value)
-    {
-        setDmrValueOn(target.get(detypedName), dmrType, value);
-    }
-
-    private ModelNode setDmrValueOn(ModelNode target, ModelType type, Object propValue)
+    public void toDmr(ModelNode target, ModelType type, Object propValue)
     {
         if(type.equals(ModelType.STRING))
         {
@@ -46,20 +41,10 @@ public class SimpleTypeAdapter {
         else if (type.equals(ModelType.BIG_DECIMAL ) ) {
             target.set((BigDecimal) propValue);
         }
-        else if(type.equals(ModelType.LIST))
-        {
-            target.setEmptyList();
-            List list = (List)propValue;
-
-            for(Object item : list)
-                target.add(String.valueOf(item));
-        }
         else
         {
             throw new RuntimeException("Unsupported DMR type: "+type);
         }
-
-        return target;
     }
 
     public void fromDmr(Object entity, String javaName, ModelType dmrType, Class<?> propertyType, ModelNode dmrPayload) throws Exception {

--- a/runtime/src/test/java/org/wildfly/swarm/config/runtime/invocation/CompositeTypesTest.java
+++ b/runtime/src/test/java/org/wildfly/swarm/config/runtime/invocation/CompositeTypesTest.java
@@ -1,0 +1,250 @@
+package org.wildfly.swarm.config.runtime.invocation;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CompositeTypesTest {
+    @Test
+    public void listOfMaps() {
+        List list = new ArrayList() {{
+            add(new HashMap() {{
+                put("foo", 1L);
+                put("bar", 2L);
+            }});
+            add(new HashMap() {{
+                put("baz", 3L);
+                put("quux", 4L);
+            }});
+        }};
+
+        ModelNode target = new ModelNode();
+        new ListTypeAdapter().toDmr(target, list);
+
+        assertEquals(ModelType.LIST, target.getType());
+
+        {
+            assertTrue(target.has(0));
+            ModelNode element = target.get(0);
+            assertEquals(ModelType.OBJECT, element.getType());
+
+            assertTrue(element.has("foo"));
+            assertEquals(ModelType.LONG, element.get("foo").getType());
+            assertEquals(1L, element.get("foo").asLong());
+
+            assertTrue(element.has("bar"));
+            assertEquals(ModelType.LONG, element.get("bar").getType());
+            assertEquals(2L, element.get("bar").asLong());
+
+            assertFalse(element.has("baz"));
+            assertFalse(element.has("quux"));
+        }
+
+        {
+            assertTrue(target.has(1));
+            ModelNode element = target.get(1);
+            assertEquals(ModelType.OBJECT, element.getType());
+
+            assertTrue(element.has("baz"));
+            assertEquals(ModelType.LONG, element.get("baz").getType());
+            assertEquals(3L, element.get("baz").asLong());
+
+            assertTrue(element.has("quux"));
+            assertEquals(ModelType.LONG, element.get("quux").getType());
+            assertEquals(4L, element.get("quux").asLong());
+
+            assertFalse(element.has("foo"));
+            assertFalse(element.has("bar"));
+        }
+
+        assertFalse(target.has(2));
+    }
+
+    @Test
+    public void mapOfLists() {
+        Map map = new HashMap() {{
+            put("foo", new ArrayList() {{
+                add(1L);
+                add("2");
+            }});
+            put("bar", new ArrayList() {{
+                add("3");
+                add(4L);
+            }});
+        }};
+
+        ModelNode target = new ModelNode();
+        new MapTypeAdapter().toDmr(target, map);
+
+        assertEquals(ModelType.OBJECT, target.getType());
+
+        {
+            assertTrue(target.has("foo"));
+            ModelNode element = target.get("foo");
+            assertEquals(ModelType.LIST, element.getType());
+
+            assertTrue(element.has(0));
+            assertEquals(ModelType.LONG, element.get(0).getType());
+            assertEquals(1L, element.get(0).asLong());
+
+            assertTrue(element.has(1));
+            assertEquals(ModelType.STRING, element.get(1).getType());
+            assertEquals("2", element.get(1).asString());
+
+            assertFalse(element.has(2));
+        }
+
+        {
+            assertTrue(target.has("bar"));
+            ModelNode element = target.get("bar");
+            assertEquals(ModelType.LIST, element.getType());
+
+            assertTrue(element.has(0));
+            assertEquals(ModelType.STRING, element.get(0).getType());
+            assertEquals("3", element.get(0).asString());
+
+            assertTrue(element.has(1));
+            assertEquals(ModelType.LONG, element.get(1).getType());
+            assertEquals(4L, element.get(1).asLong());
+
+            assertFalse(element.has(2));
+        }
+
+        assertFalse(target.has("baz"));
+        assertFalse(target.has("quux"));
+    }
+
+    @Test
+    public void listOfMapsOfLists() {
+        List list = new ArrayList() {{
+            add(new HashMap() {{
+                put("foo", new ArrayList() {{
+                    add(1L);
+                    add("2");
+                    add(true);
+                }});
+                put("bar", new ArrayList() {{
+                    add("3");
+                    add(4L);
+                    add(false);
+                }});
+            }});
+            add(new HashMap() {{
+                put("baz", new ArrayList() {{
+                    add(5L);
+                    add("6");
+                }});
+                put("quux", new ArrayList() {{
+                    add("7");
+                    add(8L);
+                }});
+            }});
+        }};
+
+        ModelNode target = new ModelNode();
+        new ListTypeAdapter().toDmr(target, list);
+
+        assertEquals(ModelType.LIST, target.getType());
+
+        {
+            assertTrue(target.has(0));
+            ModelNode element = target.get(0);
+            assertEquals(ModelType.OBJECT, element.getType());
+
+            {
+                assertTrue(element.has("foo"));
+                assertEquals(ModelType.LIST, element.get("foo").getType());
+                ModelNode nestedList = element.get("foo");
+
+                assertTrue(nestedList.has(0));
+                assertEquals(ModelType.LONG, nestedList.get(0).getType());
+                assertEquals(1L, nestedList.get(0).asLong());
+
+                assertTrue(nestedList.has(1));
+                assertEquals(ModelType.STRING, nestedList.get(1).getType());
+                assertEquals("2", nestedList.get(1).asString());
+
+                assertTrue(nestedList.has(2));
+                assertEquals(ModelType.BOOLEAN, nestedList.get(2).getType());
+                assertTrue(nestedList.get(2).asBoolean());
+
+                assertFalse(nestedList.has(3));
+            }
+
+            {
+                assertTrue(element.has("bar"));
+                assertEquals(ModelType.LIST, element.get("bar").getType());
+                ModelNode nestedList = element.get("bar");
+
+                assertTrue(nestedList.has(0));
+                assertEquals(ModelType.STRING, nestedList.get(0).getType());
+                assertEquals("3", nestedList.get(0).asString());
+
+                assertTrue(nestedList.has(1));
+                assertEquals(ModelType.LONG, nestedList.get(1).getType());
+                assertEquals(4L, nestedList.get(1).asLong());
+
+                assertTrue(nestedList.has(2));
+                assertEquals(ModelType.BOOLEAN, nestedList.get(2).getType());
+                assertFalse(nestedList.get(2).asBoolean());
+
+                assertFalse(nestedList.has(3));
+            }
+
+            assertFalse(element.has("baz"));
+            assertFalse(element.has("quux"));
+        }
+
+        {
+            assertTrue(target.has(1));
+            ModelNode element = target.get(1);
+            assertEquals(ModelType.OBJECT, element.getType());
+
+            {
+                assertTrue(element.has("baz"));
+                assertEquals(ModelType.LIST, element.get("baz").getType());
+                ModelNode nestedList = element.get("baz");
+
+                assertTrue(nestedList.has(0));
+                assertEquals(ModelType.LONG, nestedList.get(0).getType());
+                assertEquals(5L, nestedList.get(0).asLong());
+
+                assertTrue(nestedList.has(1));
+                assertEquals(ModelType.STRING, nestedList.get(1).getType());
+                assertEquals("6", nestedList.get(1).asString());
+
+                assertFalse(nestedList.has(2));
+            }
+
+            {
+                assertTrue(element.has("quux"));
+                assertEquals(ModelType.LIST, element.get("quux").getType());
+                ModelNode nestedList = element.get("quux");
+
+                assertTrue(nestedList.has(0));
+                assertEquals(ModelType.STRING, nestedList.get(0).getType());
+                assertEquals("7", nestedList.get(0).asString());
+
+                assertTrue(nestedList.has(1));
+                assertEquals(ModelType.LONG, nestedList.get(1).getType());
+                assertEquals(8L, nestedList.get(1).asLong());
+
+                assertFalse(nestedList.has(2));
+            }
+
+            assertFalse(element.has("foo"));
+            assertFalse(element.has("bar"));
+        }
+
+        assertFalse(target.has(2));
+    }
+}


### PR DESCRIPTION
Motivation
----------
To be able to fully configure Elytron, which relies on nesting
`Map`s into `List`s which are themselves nested inside `Map`s,
the `ListTypeAdapter` and `MapTypeAdapter` must be able to
convert composite types too.

Modifications
-------------
This is easiest to achieve when the adapters can delegate
to each other. To enable that, they no longer take a `ModelNode`
and a name which should be looked up in that `ModelNode`; instead,
they take the target `ModelNode` directly. This makes it natural
for each of the type adapters to delegate to the other ones.

So now:
- `SimpleTypeAdapter` handles conversion of non-composite types
- `ListTypeAdapter` handles conversion of lists and delegates to
  `SimpleTypeAdapter` for basic types and to `MapTypeAdapter`
   for maps
- `MapTypeAdapter` handles conversion of maps and delegates to
  `SimpleTypeAdapter` for basic types and to `ListTypeAdapter`
  for lists

This is naturally recursive, where `SimpleTypeAdapter` is the base
case, and it's guaranteed to complete by construction. The only case
when this procedure wouldn't complete is when the converted structure
would itself be infinite.

Result
------

First and foremost, able to fully configure Elytron.
As a nice side effect, it's now possible to put non-`String` values
into `Map`s and get correct DMR output.